### PR TITLE
Add reverse of appbar.new.window

### DIFF
--- a/WindowsPhone/svg/appbar.dock.window.svg
+++ b/WindowsPhone/svg/appbar.dock.window.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" baseProfile="full" width="76" height="76" viewBox="0 0 76.00 76.00" enable-background="new 0 0 76.00 76.00" xml:space="preserve">
-	<path fill="#000000" fill-opacity="1" stroke-width="0.2" stroke-linejoin="round" d="m 19,25.3333 23.75,0 -4.75,4.75 -14.25,0 0,22.1667 22.1667,0 0,-14.25 4.75,-4.75 0,23.75 L 19,57 19,25.3333 Z m 20.5417,23.7917 -12.6667,0 0,-12.6667 4.75,-4.75 0,8.7084 L 49.0417,23 53,26.9583 35.5833,44.375 l 8.7084,0 -4.75,4.75 z" />
+	<path fill="#000000" fill-opacity="1" stroke-width="0.2" stroke-linejoin="round" d="m 21,23.3333 23.75,0 -4.75,4.75 -14.25,0 0,22.1667 22.1667,0 0,-14.25 4.75,-4.75 0,23.75 L 21,55 21,23.3333 Z m 20.5417,23.7917 -12.6667,0 0,-12.6667 4.75,-4.75 0,8.7084 L 51.0417,21 55,24.9583 37.5833,42.375 l 8.7084,0 -4.75,4.75 z" />
 </svg>

--- a/WindowsPhone/svg/appbar.dock.window.svg
+++ b/WindowsPhone/svg/appbar.dock.window.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" baseProfile="full" width="76" height="76" viewBox="0 0 76.00 76.00" enable-background="new 0 0 76.00 76.00" xml:space="preserve">
+	<path fill="#000000" fill-opacity="1" stroke-width="0.2" stroke-linejoin="round" d="m 19,25.3333 23.75,0 -4.75,4.75 -14.25,0 0,22.1667 22.1667,0 0,-14.25 4.75,-4.75 0,23.75 L 19,57 19,25.3333 Z m 20.5417,23.7917 -12.6667,0 0,-12.6667 4.75,-4.75 0,8.7084 L 49.0417,23 53,26.9583 35.5833,44.375 l 8.7084,0 -4.75,4.75 z" />
+</svg>


### PR DESCRIPTION
I am using your icons in a desktop app that has dockable panes. I'm using `appbar.new.window` for "undocking" a pane; I'd like the same thing but with the arrow reversed to indicate "(re-)docking" a pane.

![appbar dock window 2x](https://cloud.githubusercontent.com/assets/2172537/6572933/75bd21cc-c759-11e4-827b-8a48617ed0c5.png)

The `appbar.dock.window.svg` I'm supplying indicates what I'm looking for; if it's not acceptable for inclusion as-is, feel free to reject this PR.
